### PR TITLE
更新：将flask换成fastapi的代码示例

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,18 +1,13 @@
-from flask import Flask
+from route.llm import llm_route
+from route.code_executor import code_executor_route
+from fastapi import FastAPI
+import uvicorn
+app = FastAPI()
 
-def create_app():
-    app = Flask(__name__)
-
-    with app.app_context():
-        from route.code_executor import home_bp
-        app.register_blueprint(home_bp)
-        from route.shutdown import home_bp
-        app.register_blueprint(home_bp)
-        from route.llm import home_bp
-        app.register_blueprint(home_bp)
-
-    return app
+app.include_router(llm_route)
+app.include_router(code_executor_route)
 
 if __name__ == "__main__":
-    app = create_app()
-    app.run(debug=True)
+    uvicorn.run(app,port=5000)
+
+# additional requirements: fastapi uvicorn

--- a/server/route/code_executor.py
+++ b/server/route/code_executor.py
@@ -1,14 +1,14 @@
 import io
 import sys
 import traceback
-from flask import Blueprint
-from flask import request
-home_bp = Blueprint('home', __name__)
+from fastapi import APIRouter,Request
+from json import loads
+code_executor_route = APIRouter()
 
-@home_bp.route('/execute', methods=["POST"])
-def home():
-    code = request.get_json()["code"]
-    # 创建一个 StringIO 对象来捕获输出
+@code_executor_route.post("/execute")
+async def home_execute(req:Request):
+    code = await req.body()
+    code = loads(code).get("code")
     output = io.StringIO()
     # 保存当前的 stdout
     old_stdout = sys.stdout


### PR DESCRIPTION
尽量保持原有逻辑，使用fastapi来获取更快的性能
只有示例，在实际使用过程中，需要额外的工程化标准
例如符合OpenAPI规范的文档和请求-相应模型的定义