### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/automate/providers/__init__.py
+++ b/automate/providers/__init__.py
@@ -1,9 +1,11 @@
 from .base import ChatMessage, ProviderClient, ToolCall, ToolSpec
 from .catalog import CATALOG, ProviderSpec, get_spec
+from .litellm import LiteLLMClient
 from .manager import ProviderManager
 
 __all__ = [
     "ChatMessage",
+    "LiteLLMClient",
     "ProviderClient",
     "ToolCall",
     "ToolSpec",

--- a/automate/providers/catalog.py
+++ b/automate/providers/catalog.py
@@ -60,6 +60,13 @@ CATALOG: tuple[ProviderSpec, ...] = (
         ("command-r-plus",)),
 
     # ---------- Aggregators / multi-model ----------
+    ProviderSpec("litellm", "LiteLLM Gateway", "global", "litellm",
+        "",
+        "https://docs.litellm.ai/docs/providers",
+        "",
+        ("openai/gpt-4o", "anthropic/claude-sonnet-4-6", "gemini/gemini-2.5-flash"),
+        requires_key=False,
+        notes="AI gateway to 100+ providers. Use provider-prefixed model names. API keys are read from provider env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) or set explicitly."),
     ProviderSpec("openrouter", "OpenRouter", "global", "openai_compat",
         "https://openrouter.ai/api/v1",
         "https://openrouter.ai/docs",

--- a/automate/providers/litellm.py
+++ b/automate/providers/litellm.py
@@ -1,0 +1,140 @@
+"""LiteLLM provider — routes to 100+ LLM providers via a unified interface.
+
+Install: ``pip install automate-hub[litellm]``
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Iterator
+
+from .base import ChatMessage, ChatResponse, ProviderClient, ToolCall, ToolSpec
+
+
+class LiteLLMClient(ProviderClient):
+    spec_id = "litellm"
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        timeout: int = 120,
+    ):
+        self.model = model
+        self.api_key = api_key
+        self.api_base = api_base
+        self.timeout = timeout
+
+    @staticmethod
+    def _serialize_messages(messages: list[ChatMessage]) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for m in messages:
+            d: dict[str, Any] = {"role": m.role, "content": m.content or ""}
+            if m.name:
+                d["name"] = m.name
+            if m.tool_calls:
+                d["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.name,
+                            "arguments": json.dumps(tc.arguments),
+                        },
+                    }
+                    for tc in m.tool_calls
+                ]
+            if m.tool_call_id:
+                d["tool_call_id"] = m.tool_call_id
+            out.append(d)
+        return out
+
+    def _build_kwargs(
+        self,
+        messages: list[ChatMessage],
+        *,
+        model: str,
+        tools: list[ToolSpec] | None = None,
+        temperature: float = 0.2,
+        max_tokens: int | None = None,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "model": model or self.model,
+            "messages": self._serialize_messages(messages),
+            "temperature": temperature,
+            "drop_params": True,
+            "timeout": self.timeout,
+        }
+        if max_tokens:
+            kwargs["max_tokens"] = max_tokens
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+        if tools:
+            kwargs["tools"] = [t.to_openai() for t in tools]
+            kwargs["tool_choice"] = "auto"
+        return kwargs
+
+    def chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        model: str,
+        tools: list[ToolSpec] | None = None,
+        temperature: float = 0.2,
+        max_tokens: int | None = None,
+    ) -> ChatResponse:
+        import litellm
+
+        kwargs = self._build_kwargs(
+            messages,
+            model=model,
+            tools=tools,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        response = litellm.completion(**kwargs)
+        return self._parse_response(response)
+
+    def stream(
+        self,
+        messages: list[ChatMessage],
+        *,
+        model: str,
+        tools: list[ToolSpec] | None = None,
+        temperature: float = 0.2,
+        max_tokens: int | None = None,
+    ) -> Iterator[dict]:
+        import litellm
+
+        kwargs = self._build_kwargs(
+            messages,
+            model=model,
+            tools=tools,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        kwargs["stream"] = True
+        for chunk in litellm.completion(**kwargs):
+            delta = chunk.choices[0].delta if chunk.choices else None
+            if delta:
+                yield {
+                    "delta": getattr(delta, "content", "") or "",
+                    "tool_calls": getattr(delta, "tool_calls", []) or [],
+                }
+
+    @staticmethod
+    def _parse_response(response: Any) -> ChatResponse:
+        choice = response.choices[0].message
+        content = getattr(choice, "content", "") or ""
+        tool_calls: list[ToolCall] = []
+        for tc in getattr(choice, "tool_calls", None) or []:
+            fn = tc.function
+            try:
+                args = json.loads(fn.arguments or "{}")
+            except json.JSONDecodeError:
+                args = {"_raw": fn.arguments}
+            tool_calls.append(ToolCall(id=tc.id, name=fn.name, arguments=args))
+        return ChatResponse(content=content, tool_calls=tool_calls, raw=response)

--- a/automate/providers/manager.py
+++ b/automate/providers/manager.py
@@ -5,6 +5,7 @@ from ..store import Database
 from .anthropic import AnthropicClient
 from .base import ProviderClient
 from .catalog import CATALOG, get_spec
+from .litellm import LiteLLMClient
 from .openai_compat import OpenAICompatClient
 
 
@@ -58,6 +59,12 @@ class ProviderManager:
         if spec.requires_key and not row.get("api_key"):
             raise RuntimeError(f"Provider '{pid}' has no API key configured.")
         base_url = row.get("base_url") or spec.base_url
+        if spec.adapter == "litellm":
+            return LiteLLMClient(
+                model=row.get("default_model") or "",
+                api_key=row.get("api_key"),
+                api_base=base_url or None,
+            )
         if spec.adapter == "anthropic":
             return AnthropicClient(
                 base_url=base_url,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# LiteLLM AI gateway (100+ providers via unified interface)
+litellm = ["litellm>=1.65,<1.85"]
 # Browser execution (Playwright). After install: `python -m playwright install chromium`
 browser = ["playwright>=1.40"]
 # Desktop execution (screenshot / mouse / keyboard). Skip on headless servers.

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,110 @@
+import json
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+from automate.providers.base import ChatMessage, ToolSpec
+
+
+def _install_litellm_stub():
+    fake = types.ModuleType("litellm")
+    fake.completion = mock.MagicMock(name="litellm.completion")
+    sys.modules["litellm"] = fake
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def litellm_stub():
+    fake = _install_litellm_stub()
+    yield fake
+    sys.modules.pop("litellm", None)
+
+
+def _mock_response(content: str = "Hello!", tool_calls=None):
+    from types import SimpleNamespace
+
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls or [])
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+def test_chat_calls_litellm_completion(litellm_stub):
+    litellm_stub.completion.return_value = _mock_response("reply")
+
+    from automate.providers.litellm import LiteLLMClient
+
+    client = LiteLLMClient(model="anthropic/claude-haiku-4-5", api_key="sk-test")
+    resp = client.chat(
+        [ChatMessage(role="user", content="Hi")],
+        model="anthropic/claude-haiku-4-5",
+    )
+
+    litellm_stub.completion.assert_called_once()
+    kwargs = litellm_stub.completion.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-haiku-4-5"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["drop_params"] is True
+    assert resp.content == "reply"
+
+
+def test_chat_omits_blank_credentials(litellm_stub):
+    litellm_stub.completion.return_value = _mock_response()
+
+    from automate.providers.litellm import LiteLLMClient
+
+    client = LiteLLMClient(model="openai/gpt-4o")
+    client.chat([ChatMessage(role="user", content="Hi")], model="openai/gpt-4o")
+
+    kwargs = litellm_stub.completion.call_args.kwargs
+    assert "api_key" not in kwargs
+    assert "api_base" not in kwargs
+
+
+def test_chat_forwards_tools(litellm_stub):
+    litellm_stub.completion.return_value = _mock_response()
+
+    from automate.providers.litellm import LiteLLMClient
+
+    tool = ToolSpec(name="search", description="Search the web", parameters={"type": "object", "properties": {}})
+    client = LiteLLMClient(model="openai/gpt-4o", api_key="k")
+    client.chat(
+        [ChatMessage(role="user", content="Find info")],
+        model="openai/gpt-4o",
+        tools=[tool],
+    )
+
+    kwargs = litellm_stub.completion.call_args.kwargs
+    assert kwargs["tool_choice"] == "auto"
+    assert len(kwargs["tools"]) == 1
+    assert kwargs["tools"][0]["function"]["name"] == "search"
+
+
+def test_chat_parses_tool_call_response(litellm_stub):
+    from types import SimpleNamespace
+
+    tc = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="search", arguments=json.dumps({"q": "test"})),
+    )
+    litellm_stub.completion.return_value = _mock_response("", tool_calls=[tc])
+
+    from automate.providers.litellm import LiteLLMClient
+
+    client = LiteLLMClient(model="openai/gpt-4o", api_key="k")
+    resp = client.chat(
+        [ChatMessage(role="user", content="Hi")],
+        model="openai/gpt-4o",
+    )
+
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].name == "search"
+    assert resp.tool_calls[0].arguments == {"q": "test"}
+
+
+def test_catalog_contains_litellm():
+    from automate.providers.catalog import get_spec
+
+    spec = get_spec("litellm")
+    assert spec is not None
+    assert spec.adapter == "litellm"


### PR DESCRIPTION
  ## Summary                      
  - Adds LiteLLM as a native provider adapter alongside OpenAI-compat and Anthropic                                                                                                                                  
  - Enables access to 100+ LLM providers via provider-prefixed model names (e.g. `anthropic/claude-sonnet-4-6`, `gemini/gemini-2.5-flash`)
                                                                                                                                                                                                                   
  ## Motivation                                                                                                                                                                                                      
  autoMate already supports 20+ providers via OpenAI-compatible endpoints and a dedicated Anthropic adapter. LiteLLM adds a unified gateway that handles provider-specific parameter translation, retry logic, and   
  authentication, letting users access any provider without configuring individual base URLs.                                                                                                                        

                                                                                                                                                                                                                     
  ## Changes      
  - `automate/providers/litellm.py` - New `LiteLLMClient` implementing `ProviderClient` protocol with `chat()` and `stream()` methods
  - `automate/providers/catalog.py` - Added `litellm` ProviderSpec entry in the Aggregators section
  - `automate/providers/manager.py` - Wired `LiteLLMClient` instantiation for `adapter="litellm"`                                                                                                                  
  - `automate/providers/__init__.py` - Exported `LiteLLMClient`                                                                                                                                                      
  - `pyproject.toml` - Added `litellm>=1.65,<1.85` as optional dependency under `[project.optional-dependencies].litellm`                                                                                          
  - `tests/test_litellm_provider.py` - 5 unit tests covering completion dispatch, credential forwarding, tool call handling, and catalog registration                                                                
                                                                                                                                                                                                                   
  ## Tests                                                                                                                                                    
                                                                                                                                                                                                                     
  **1. Unit tests:** `pytest tests/test_litellm_provider.py -v`                                                                                                                                                      
  ```                                                                                                                                                                                                                
  tests/test_litellm_provider.py::test_chat_calls_litellm_completion PASSED [ 20%]
  tests/test_litellm_provider.py::test_chat_omits_blank_credentials PASSED [ 40%]
  tests/test_litellm_provider.py::test_chat_forwards_tools PASSED          [ 60%]                                                                                                                                  
  tests/test_litellm_provider.py::test_chat_parses_tool_call_response PASSED [ 80%]                                                                                                                                  
  tests/test_litellm_provider.py::test_catalog_contains_litellm PASSED     [100%]                                                                                                                                    
                                                                                                                                                                                                                     
  ============================== 5 passed in 0.07s ===============================                                                                                                                                   
  ```                             
                                                                                                                                                                                                                     
  ## Usage        
                                                                                                                                                                                                                   
  **Install:**                                                                                                                                                                                                       
  ```bash                         
  pip install automate-hub[litellm]                                                                                                                                                                                  
  ```             

  **GUI:** Select "LiteLLM Gateway" as the provider in the settings panel, then configure:
  - Model: `anthropic/claude-sonnet-4-6` (or any provider-prefixed model name)                                                                                                                                     
  - API Key: your provider key, or leave blank if the corresponding env var is set (e.g. `ANTHROPIC_API_KEY`)                                                                                                        
                                  
  **Python:**                                                                                                                                                                                                        
  ```python                                                                                                                                                                                                          
  from automate.providers.litellm import LiteLLMClient
  from automate.providers.base import ChatMessage                                                                                                                                                                    
                  
  client = LiteLLMClient(                                                                                                                                                                                          
      model="anthropic/claude-sonnet-4-6",                                                                                                                                                                           
      api_key="sk-ant-..."        
  )                                                                                                                                                                                                                  
                  
  response = client.chat(
      [ChatMessage(role="user", content="Open the browser and search for weather")],                                                                                                                               
      model="anthropic/claude-sonnet-4-6"                                                                                                                                                                            
  )                                                                                                                                                                                                                
  print(response.content)                                                                                                                                                                                            
  ```                             
                                                                                                                                                                                                                     
  **Environment variables (no api_key needed):**
  ```bash                                                                                                                                                                                                          
  export ANTHROPIC_API_KEY=sk-ant-...                                                                                                                                                                                
  ```                             
  ```python                                                                                                                                                                                                          
  # LiteLLM reads provider env vars automatically
  client = LiteLLMClient(model="anthropic/claude-sonnet-4-6")
  response = client.chat(                                                                                                                                                                                          
      [ChatMessage(role="user", content="Hello")],                                                                                                                                                                   
      model="anthropic/claude-sonnet-4-6"
  )                                                                                                                                                                                                                  
  ```                                                                                                                                                                                                                
                                  
  **Streaming:**                                                                                                                                                                                                     
  ```python       
  for chunk in client.stream(
      [ChatMessage(role="user", content="Write a short poem")],
      model="openai/gpt-4o"                                                                                                                                                                                        
  ):                                                                                                                                                                                                                 
      print(chunk["delta"], end="", flush=True)
  ```                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  ## Risk / Compatibility         
  - Additive only. Existing `openai_compat` and `anthropic` adapters untouched.                                                                                                                                      
  - `litellm` is an optional dependency. Base install unaffected.
  - LiteLLM lazy-imported inside method bodies to avoid import errors when not installed.
  - `drop_params=True` by default for cross-provider kwarg compatibility.                                                                                                                                          
