### PR TITLE
feat(providers): 新增 Atlas Cloud，并修掉它暴露出的两个通用客户端 bug

### DIFF
--- a/automate/providers/anthropic.py
+++ b/automate/providers/anthropic.py
@@ -9,7 +9,7 @@ import json
 import urllib.request
 from typing import Iterator
 
-from .base import ChatMessage, ChatResponse, ProviderClient, ToolCall, ToolSpec
+from .base import USER_AGENT, ChatMessage, ChatResponse, ProviderClient, ToolCall, ToolSpec
 
 
 class AnthropicClient(ProviderClient):
@@ -24,6 +24,7 @@ class AnthropicClient(ProviderClient):
     def _headers(self) -> dict:
         return {
             "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
             "x-api-key": self.api_key,
             "anthropic-version": "2023-06-01",
         }

--- a/automate/providers/base.py
+++ b/automate/providers/base.py
@@ -7,6 +7,14 @@ Groq, Ollama, OpenRouter) speaks it natively or via a thin shim.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+
+from ..version import __version__
+
+# urllib sends "Python-urllib/3.x" by default and some providers' edge layers
+# reject that outright -- Atlas Cloud answers 403 "error code: 1010" for it,
+# while the identical request with any real agent string succeeds. The plain
+# urllib clients below send this instead.
+USER_AGENT = f"autoMate/{__version__}"
 from typing import Any, Iterator, Protocol
 
 

--- a/automate/providers/catalog.py
+++ b/automate/providers/catalog.py
@@ -91,6 +91,12 @@ CATALOG: tuple[ProviderSpec, ...] = (
         "https://api.deepinfra.com/v1/openai",
         "https://deepinfra.com/docs",
         "https://deepinfra.com/dash/api_keys"),
+    ProviderSpec("atlascloud", "Atlas Cloud", "global", "openai_compat",
+        "https://api.atlascloud.ai/v1",
+        "https://docs.atlascloud.ai",
+        "https://www.atlascloud.ai/console/api-keys",
+        ("qwen/qwen3.5-35b-a3b", "zai-org/glm-5", "moonshotai/kimi-k2.6", "deepseek-ai/DeepSeek-V3.1"),
+        notes="One key for open-weights models; model names are vendor-prefixed. GET /v1/models lists what the key can reach."),
 
     # ---------- China ----------
     ProviderSpec("deepseek", "DeepSeek", "china", "openai_compat",

--- a/automate/providers/openai_compat.py
+++ b/automate/providers/openai_compat.py
@@ -11,7 +11,7 @@ import urllib.error
 import urllib.request
 from typing import Iterator
 
-from .base import ChatMessage, ChatResponse, ProviderClient, ToolCall, ToolSpec
+from .base import USER_AGENT, ChatMessage, ChatResponse, ProviderClient, ToolCall, ToolSpec
 
 
 class OpenAICompatClient(ProviderClient):
@@ -24,7 +24,7 @@ class OpenAICompatClient(ProviderClient):
         self.timeout = timeout
 
     def _headers(self) -> dict:
-        h = {"Content-Type": "application/json"}
+        h = {"Content-Type": "application/json", "User-Agent": USER_AGENT}
         if self.api_key:
             h["Authorization"] = f"Bearer {self.api_key}"
         return h
@@ -108,5 +108,12 @@ class OpenAICompatClient(ProviderClient):
                     chunk = json.loads(payload)
                 except json.JSONDecodeError:
                     continue
-                delta = chunk["choices"][0].get("delta", {})
+                choices = chunk.get("choices") or []
+                if not choices:
+                    # Usage-only terminal chunk: it carries token counts and an
+                    # empty choices list. Atlas Cloud sends one unconditionally,
+                    # OpenAI with stream_options.include_usage -- indexing [0]
+                    # here raised IndexError at the very end of every stream.
+                    continue
+                delta = choices[0].get("delta", {})
                 yield {"delta": delta.get("content") or "", "tool_calls": delta.get("tool_calls") or []}


### PR DESCRIPTION
## 这是什么

`automate/providers/catalog.py` 的开头写着 *"Adding a new provider = appending a single ``ProviderSpec`` here."* —— 这个 PR 先照着做了（Atlas Cloud 放在 Aggregators / multi-model 分组，和 OpenRouter / Together / Fireworks / DeepInfra 一起）。

但真的把它跑起来之后，撞到了通用 urllib 客户端里的**两个和供应商无关的 bug**，一并修了：

### 1. 没发 User-Agent，走的是 urllib 默认的 `Python-urllib/3.x`

`OpenAICompatClient._headers()` 只发 `Content-Type` + `Authorization`。有些供应商的边缘层直接拒绝默认 UA —— Atlas Cloud 回 `403 error code: 1010`，同一个请求换成任意真实 UA 就 200。

实测（就用本仓的客户端，只把 `_headers` 换回改动前的版本）：

```
改动前 -> RuntimeError: atlascloud HTTP 403: error code: 1010
改动后 -> 'hello from atlas cloud'
```

`base.py` 现在导出 `USER_AGENT = f"autoMate/{__version__}"`，两个 urllib 客户端（`openai_compat` 与 `anthropic`）都带上。这不是给某一家开特例：任何挂在 Cloudflare 之类边缘层后面的 endpoint 都可能这么拦，而默认 UA 本来也没有表明是 autoMate 发出的请求。

### 2. `stream()` 在每条流的结尾都会 IndexError

```python
delta = chunk["choices"][0].get("delta", {})   # 改动前
```

最后一个 chunk 是 usage-only 的：`"choices": []` 加上 token 统计。OpenAI 在设了 `stream_options.include_usage` 时会发，Atlas Cloud 无条件发。所以 `[0]` 会抛 `IndexError: list index out of range`——**流一路正常，最后一刻炸掉**。

实测的 chunk 序列：56 个 chunk，其中第 56 个是 `{"choices": [], "usage": {...}}`。改动后跳过没有 choices 的 chunk。

## 验证

全部用本仓自己的 `OpenAICompatClient` + `catalog.get_spec("atlascloud")` 打真实接口，不是自己另写的 client：

| 路径 | 结果 |
|---|---|
| `chat()` 普通对话 | `'hello from atlas cloud'` |
| `chat()` 带 tools | `click {'x': 120, 'y': 340}` |
| `stream()` 文本 | 948 个事件，拼出 `'1 2 3 4 5'`（改动前：末尾 IndexError） |
| `stream()` 带 tools | 9 个工具调用片段，首片 `{'id': 'call_...', 'function': {'name': ...}}` |

工具调用这两条是关键：autoMate 靠它驱动 GUI 操作，所以我用了 `click(x, y)` 这种形状的工具来验。

另外确认没有回归：`AnthropicClient._headers()` 仍然带齐 `x-api-key` 与 `anthropic-version`，只是多了一个 `User-Agent`；catalog 从 27 条变 28 条，其余条目一字未动。仓库自带的 `tests/test_litellm_provider.py` 我这边没有 pytest 环境跑，但改动没有碰 litellm 那条路径。

## 利益披露

我在 Atlas Cloud 工作。catalog 那条是一条 OpenAI 兼容入口、用用户自己的 key，不选它就完全不生效。上面两个 bug 修复对所有供应商都有效，如果你们希望把它们拆成独立 PR、只留 catalog 那一条，我照办。
